### PR TITLE
Restore Python/C API after solving deadlock issues and zero-copy

### DIFF
--- a/example/screen_to_browser.py
+++ b/example/screen_to_browser.py
@@ -155,8 +155,9 @@ def stripe_callback_handler(result_obj, user_data_obj):
     """Callback invoked by pixelflux when a new video stripe is ready."""
     if g_is_capturing and result_obj and g_h264_stripe_queue is not None:
         if g_loop and not g_loop.is_closed():
+            # Get the memoryview from the result object (which supports buffer protocol)
             asyncio.run_coroutine_threadsafe(
-                g_h264_stripe_queue.put(result_obj.data), g_loop
+                g_h264_stripe_queue.put(memoryview(result_obj)), g_loop
             )
 
 

--- a/pixelflux/screen_capture_module.cpp
+++ b/pixelflux/screen_capture_module.cpp
@@ -4065,16 +4065,15 @@ static void py_stripe_callback_trampoline(StripeEncodeResult* result, void* user
       return;
   }
 
-  PyGILState_STATE gstate = PyGILState_Ensure();
-
   if (!py_capture_module->py_callback_obj) {
       if (result && result->data) {
           delete[] result->data;
           result->data = nullptr;
       }
-      PyGILState_Release(gstate);
       return;
   }
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
 
   if (result && result->data) {
     PyStripeEncodeResult* py_result_obj = (PyStripeEncodeResult*)PyStripeEncodeResultType.tp_alloc(&PyStripeEncodeResultType, 0);


### PR DESCRIPTION
- [Use zero-copy memoryview instead of bytes](https://github.com/linuxserver/pixelflux/commit/1b7719fae6752ed4b51ec337ab99c70c7b4412e6)
- [Fix deadlock issue](https://github.com/linuxserver/pixelflux/commit/37b724140a04b5142733dad0fa9ad2217b8bc4f2)