### PR TITLE
Extra configuration for h264 mode to support webrtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,16 @@ settings.jpeg_quality = 75              # Quality for changed stripes (0-100)
 settings.paint_over_jpeg_quality = 90   # Quality for static "paint-over" stripes (0-100)
 
 # --- H.264 Settings ---
-settings.h264_crf = 25                   # CRF value (0-51, lower is better quality/higher bitrate)
-settings.h264_paintover_crf = 18         # CRF for H.264 paintover on static content. Must be lower than h264_crf to activate.
-settings.h264_paintover_burst_frames = 5 # Number of high-quality frames to send in a burst when a paintover is triggered.
-settings.h264_fullcolor = False          # Use I444 (full color) instead of I420 for software encoding
-settings.h264_fullframe = True           # Encode full frames (required for HW accel) instead of just changed stripes
-settings.h264_streaming_mode = False     # Bypass all VNC logic and work like a normal video encoder, higher constant CPU usage for fullscreen gaming/videos
+settings.h264_crf = 25                            # CRF value (0-51, lower is better quality/higher bitrate)
+settings.h264_paintover_crf = 18                  # CRF for H.264 paintover on static content. Must be lower than h264_crf to activate.
+settings.h264_paintover_burst_frames = 5          # Number of high-quality frames to send in a burst when a paintover is triggered.
+settings.h264_fullcolor = False                   # Use I444 (full color) instead of I420 for software encoding
+settings.h264_fullframe = True                    # Encode full frames (required for HW accel) instead of just changed stripes
+settings.h264_streaming_mode = False              # Bypass all VNC logic and work like a normal video encoder, higher constant CPU usage for fullscreen gaming/videos
+settings.h264_cbr_mode = False                    # Switches to CBR mode and ignores CRF value. Used in conjunction with h264_bitrate_kbps.
+settings.h264_bitrate_kbps = 4000                 # Target bitrate for CBR mode. Required when h264_cbr_mode is enabled.
+settings.h264_vbv_buffer_size_kb = 400            # Optional VBV buffer size in kilobits for custom buffer size.
+settings.auto_adjust_screen_capture_size = True   # Allow pixelflux to adjust its capture width and height.
 
 # --- Hardware Acceleration ---
 # >= 0: Enable GPU Encoding on /dev/dri/renderD(128 + index)

--- a/example/screen_to_browser.py
+++ b/example/screen_to_browser.py
@@ -63,6 +63,15 @@ base_capture_settings.h264_fullframe = False
 base_capture_settings.h264_streaming_mode = False
 # Pass a vaapi node index 0 = renderD128, -1 to disable
 base_capture_settings.vaapi_render_node_index = -1
+# Switches to CBR mode and ignores CRF value. Used in conjunction with h264_bitrate_kbps.
+base_capture_settings.h264_cbr_mode = False
+# Target bitrate in kbps for CBR mode. Required when h264_cbr_mode is enabled.
+base_capture_settings.h264_bitrate_kbps = 4000
+# Optional VBV buffer size in kilobits for custom buffer size.
+base_capture_settings.h264_vbv_buffer_size_kb = 400
+# Allow pixelflux to adjust its capture width and height. Overrides provided width and height when enabled.
+base_capture_settings.auto_adjust_screen_capture_size = True
+#
 
 # --- Change Detection & Optimization ---
 # Use a higher quality setting for static regions that haven't changed for a while.

--- a/pixelflux/__init__.py
+++ b/pixelflux/__init__.py
@@ -69,6 +69,8 @@ if _legacy_lib:
     stop_capture_c.argtypes = [ctypes.c_void_p]
     free_stripe_encode_result_data = _legacy_lib.free_stripe_encode_result_data
     free_stripe_encode_result_data.argtypes = [ctypes.POINTER(StripeEncodeResult)]
+    request_idr = _legacy_lib.screen_capture_request_idr
+    request_idr.argtypes = [ctypes.c_void_p]
 
 _GLOBAL_WAYLAND_BACKEND = None
 if os.environ.get("PIXELFLUX_WAYLAND") == "true":
@@ -219,3 +221,7 @@ class ScreenCapture:
     def set_cursor_callback(self, callback):
         if _GLOBAL_WAYLAND_BACKEND:
             _GLOBAL_WAYLAND_BACKEND.set_cursor_callback(callback)
+
+    def request_idr_frame(self):
+        if self._is_capturing and self._module:
+            request_idr(self._module)

--- a/pixelflux/__init__.py
+++ b/pixelflux/__init__.py
@@ -30,6 +30,10 @@ class CaptureSettings(ctypes.Structure):
         ("vaapi_render_node_index", ctypes.c_int),
         ("use_cpu", ctypes.c_bool),
         ("debug_logging", ctypes.c_bool),
+        ("h264_cbr_mode", ctypes.c_bool),
+        ("h264_bitrate_kbps", ctypes.c_int),
+        ("h264_vbv_buffer_size_kb", ctypes.c_int),
+        ("auto_adjust_screen_capture_size", ctypes.c_bool),
     ]
 
 class StripeEncodeResult(ctypes.Structure):
@@ -69,9 +73,15 @@ if _legacy_lib:
     stop_capture_c.argtypes = [ctypes.c_void_p]
     free_stripe_encode_result_data = _legacy_lib.free_stripe_encode_result_data
     free_stripe_encode_result_data.argtypes = [ctypes.POINTER(StripeEncodeResult)]
-    request_idr = _legacy_lib.screen_capture_request_idr
+    request_idr = _legacy_lib.request_idr
     request_idr.argtypes = [ctypes.c_void_p]
-
+    update_video_bitrate_c = _legacy_lib.update_video_bitrate
+    update_video_bitrate_c.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    update_framerate_c = _legacy_lib.update_framerate
+    update_framerate_c.argtypes = [ctypes.c_void_p, ctypes.c_double]
+    update_vbv_buffer_size_c = _legacy_lib.update_vbv_buffer_size
+    update_vbv_buffer_size_c.argtypes = [ctypes.c_void_p, ctypes.c_int]
+ 
 _GLOBAL_WAYLAND_BACKEND = None
 if os.environ.get("PIXELFLUX_WAYLAND") == "true":
     try:
@@ -225,3 +235,15 @@ class ScreenCapture:
     def request_idr_frame(self):
         if self._is_capturing and self._module:
             request_idr(self._module)
+
+    def update_video_bitrate(self, bitrate):
+        if self._is_capturing and self._module:
+            update_video_bitrate_c(self._module, bitrate)
+    
+    def update_framerate(self, fps):
+        if self._is_capturing and self._module:
+            update_framerate_c(self._module, ctypes.c_double(fps))
+    
+    def update_vbv_buf_size(self, buffer_size):
+        if self._is_capturing and self._module:
+            update_vbv_buffer_size_c(self._module, buffer_size)

--- a/pixelflux/screen_capture_module.cpp
+++ b/pixelflux/screen_capture_module.cpp
@@ -1645,9 +1645,9 @@ bool ScreenCaptureModule::initialize_vaapi_encoder(int render_node_idx, int widt
     av_opt_set(vaapi_state_.codec_ctx->priv_data, "tune", "zerolatency", 0);
     av_opt_set(vaapi_state_.codec_ctx->priv_data, "preset", "ultrafast", 0);
     if (use_yuv444) {
-        av_opt_set_int(vaapi_state_.codec_ctx, "profile", FF_PROFILE_H264_HIGH_444_PREDICTIVE, 0);
+        av_opt_set_int(vaapi_state_.codec_ctx, "profile", AV_PROFILE_H264_HIGH_444_PREDICTIVE, 0);
     } else {
-        av_opt_set_int(vaapi_state_.codec_ctx, "profile", FF_PROFILE_H264_HIGH, 0);
+        av_opt_set_int(vaapi_state_.codec_ctx, "profile", AV_PROFILE_H264_HIGH, 0);
     }
 
      if (is_cbr) {


### PR DESCRIPTION
Added two config options:
- auto-adjust-capture-size: To allow pixelflux to adjust it's capture size automatically based on Xserver API calls overriding user specified width and height.
- VBV buffer size to let user provide custom buffer size for h264 CBR mode

Exposed APIs to update:
- Video bitrate
- framerate
- vbv buffer size
-  IDR request

