### PR TITLE
fix(wayland): scale watermark buffer with output_scale to fix hi-DPI overflow

### DIFF
--- a/pixelflux_wayland/src/encoders/overlay.rs
+++ b/pixelflux_wayland/src/encoders/overlay.rs
@@ -76,23 +76,12 @@ impl OverlayState {
     /// @brief Loads an image from disk to use as the watermark.
     /// @input path: Filesystem path to the image.
     /// @input output_scale: The current output's fractional scale factor.
-    /// Used as the buffer's logical-to-physical scale so the rendered overlay
-    /// occupies the same physical extent as its source pixel dimensions.
-    /// Without this, on outputs with scale > 1 the buffer is rendered at
-    /// `pixel_size * output_scale` while position math (`frame_w - wm_w`)
-    /// still uses `wm_w` as if it were physical, causing the watermark to
-    /// extend past the right/bottom of the frame for any anchor other than
-    /// TL (where both anchor coords are 0 and the scale is a no-op).
     pub fn load_watermark(&mut self, path: &str, output_scale: f64) {
         if let Ok(img) = image::open(Path::new(path)) {
             let rgba = img.to_rgba8();
             self.wm_width = rgba.width();
             self.wm_height = rgba.height();
             self.wm_loaded = true;
-
-            // Round up so a 1.5 fractional scale doesn't clip off-screen
-            // (it may inset the watermark slightly from the edge instead).
-            // For integer scales (1, 2) this is exact and the math works out.
             let buffer_scale = output_scale.ceil().max(1.0) as i32;
 
             self.render_buffer = Some(MemoryRenderBuffer::from_slice(

--- a/pixelflux_wayland/src/encoders/overlay.rs
+++ b/pixelflux_wayland/src/encoders/overlay.rs
@@ -75,18 +75,31 @@ impl Default for OverlayState {
 impl OverlayState {
     /// @brief Loads an image from disk to use as the watermark.
     /// @input path: Filesystem path to the image.
-    pub fn load_watermark(&mut self, path: &str) {
+    /// @input output_scale: The current output's fractional scale factor.
+    /// Used as the buffer's logical-to-physical scale so the rendered overlay
+    /// occupies the same physical extent as its source pixel dimensions.
+    /// Without this, on outputs with scale > 1 the buffer is rendered at
+    /// `pixel_size * output_scale` while position math (`frame_w - wm_w`)
+    /// still uses `wm_w` as if it were physical, causing the watermark to
+    /// extend past the right/bottom of the frame for any anchor other than
+    /// TL (where both anchor coords are 0 and the scale is a no-op).
+    pub fn load_watermark(&mut self, path: &str, output_scale: f64) {
         if let Ok(img) = image::open(Path::new(path)) {
             let rgba = img.to_rgba8();
             self.wm_width = rgba.width();
             self.wm_height = rgba.height();
             self.wm_loaded = true;
 
+            // Round up so a 1.5 fractional scale doesn't clip off-screen
+            // (it may inset the watermark slightly from the edge instead).
+            // For integer scales (1, 2) this is exact and the math works out.
+            let buffer_scale = output_scale.ceil().max(1.0) as i32;
+
             self.render_buffer = Some(MemoryRenderBuffer::from_slice(
                 &rgba.into_vec(),
                 Fourcc::Abgr8888,
                 (self.wm_width as i32, self.wm_height as i32),
-                1,
+                buffer_scale,
                 Transform::Normal,
                 None,
             ));

--- a/pixelflux_wayland/src/lib.rs
+++ b/pixelflux_wayland/src/lib.rs
@@ -775,7 +775,14 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
 
                     println!("{}", log_msg);
 
-                    state.overlay_state.load_watermark(&settings.watermark_path);
+                    let watermark_output_scale = state
+                        .outputs
+                        .first()
+                        .map(|o| o.current_scale().fractional_scale())
+                        .unwrap_or(1.0);
+                    state
+                        .overlay_state
+                        .load_watermark(&settings.watermark_path, watermark_output_scale);
                     state.callback = Some(cb);
                     state.is_capturing = true;
                     state.render_cursor_on_framebuffer = settings.capture_cursor; 


### PR DESCRIPTION
Fixes #12.

## Summary

On the Wayland backend, the watermark `MemoryRenderBuffer` is created with `buffer_scale = 1` while the position math anchors the buffer using `frame_w - wm_width` in physical pixels. When `output_scale > 1`, the buffer is rendered at `pixel_size * output_scale` (Smithay's logical-to-physical scaling) but the position math still subtracts the buffer's *pixel* size, so the watermark spills off the right by `wm_width` and over the bottom by `wm_height` for every anchor except `TL` (where both anchor coords are `(0, 0)` and the scale multiplication is a no-op).

This patch passes the current output's `fractional_scale()` into `load_watermark` and sets `buffer_scale = ceil(output_scale).max(1.0) as i32`. With buffer_scale matching the integer-rounded output_scale, the buffer's logical extent renders at the same physical extent as its source pixel dimensions, so the existing position math (`frame_w - wm_width`) is correct again.

## Diff size

- `pixelflux_wayland/src/encoders/overlay.rs`: +14 / −2
- `pixelflux_wayland/src/lib.rs`: +8 / −1

## Verification

I verified the fix by reasoning through the buffer-scale ↔ output-scale interaction in Smithay's `MemoryRenderBuffer` semantics, but **I have not built and run the patch end-to-end against a hi-DPI Wayland output** — I don't currently have a Rust toolchain set up against the right Smithay version. The change is small enough that I hope the reviewer can sanity-check the build locally; if you'd like me to expand verification (or if the patch needs adjustment for a Smithay API I've misread), please say.

The bug repro itself was verified end-to-end on pixelflux 1.6.2 inside `linuxserver/baseimage-selkies:alpine323` running KDE Plasma 6 / Wayland, with a 300×250 watermark PNG anchored bottom-right and Selkies UI Scaling stepped through 100 / 150 / 200 %.

## Known limitations (called out so reviewers can decide whether they're blockers)

1. **Mid-session output_scale changes** leave a stale buffer because it's only created at `load_watermark` time. If a user moves the Selkies UI Scaling slider while a capture is in progress, the bug returns until the next capture restart. A more complete fix would re-create the buffer when `output_scale` changes — happy to expand here if you'd prefer that in this PR.
2. **Fractional scales (1.5, 1.25)** round up via `ceil`, so the watermark may inset slightly from the edge rather than clipping (e.g., at scale=1.5, a 300-px-wide watermark renders at 225 physical wide and ends 75 px short of the right edge). Strictly correct fractional positioning would require treating position math in logical coordinates throughout `update_position`, which is a larger refactor; the visual effect of the current rounding is small and never extends off-screen.

## Why this matters

Any deployment that uses a Wayland desktop with a hi-DPI display — or that exposes Selkies' UI Scaling slider to users — sees the watermark partially off-screen the moment scale > 1. For deployments with a "watermark must be visible on every frame" compliance contract (SATRE / DLP-style policies), the current workaround of forcing `WATERMARK_LOCATION=1` (TopLeft) is the only mathematically immune anchor but generally conflicts with default desktop layouts.

## Linked downstream

Tracked downstream as TREAT-90 (waiting on this fix; will revert our `WATERMARK_LOCATION=1` workaround back to `4` once a release with the fix is on PyPI).