### PR TITLE
feat: optional Unix-socket fanout for the encoded H.264 stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,27 @@ The Wayland backend implements a **Zero-Copy** architecture for hardware encodin
 
 **Performance Note:** Enabling **watermarking** or utilizing a render node different from the encoding node will force a "Readback" fallback, copying pixels to the CPU and breaking the zero-copy chain. This increases latency and CPU load.
 
+## Recording Sink (Wayland)
+
+The Wayland backend can output the raw H.264 video stream directly to a Unix domain socket for external recording.
+
+*Note: This feature requires full-frame H.264 encoding (CPU, VA-API, or NVENC) and does not work with JPEG or striped H.264 modes.*
+
+```python
+# Enable the unix socket (forces IDR frames every 30 frames and on connect)
+settings.recording_socket = "/tmp/pixelflux_record"
+```
+
+You can then capture the stream using `ffmpeg`:
+
+```bash
+# Raw copy
+ffmpeg -f h264 -i unix:///tmp/pixelflux_record -c:v copy test.h264
+
+# Re-encode for a clean MP4
+ffmpeg -f h264 -framerate 60 -i unix:///tmp/pixelflux_record -c:v libx264 -preset fast -crf 23 -pix_fmt yuv420p test.mp4
+```
+
 ## Features
 
 *   **Hybrid Backend:**
@@ -220,6 +241,7 @@ The Wayland backend implements a **Zero-Copy** architecture for hardware encodin
 *   **Input Handling:** Built-in input injection for mouse and keyboard (Wayland).
 *   **Cursor Compositing:** Hardware cursor planes or software rendering options.
 *   **Dynamic Watermarking:** Overlay PNGs with static positioning or DVD-screensaver style animation.
+*   **Recording Sink:** Direct Unix socket output of full-frame H.264 streams for local capture.
 
 ## License
 

--- a/example/screen_to_browser.py
+++ b/example/screen_to_browser.py
@@ -96,6 +96,14 @@ base_capture_settings.paint_over_jpeg_quality = 90
 # Options: 0:None, 1:TopLeft, 2:TopRight, 3:BottomLeft, 4:BottomRight, 5:Middle, 6:Animated
 base_capture_settings.watermark_location_enum = 0
 
+# --- Recording ---
+# When this is set to a valid path (string) will enable a unix socket for recording
+# i.e. '/tmp/test' can be recorded with "ffmpeg -f h264 -i unix:///tmp/test -c:v copy test.h264"
+# For a clean recording the stream might need a re-encode i.e.:
+# "ffmpeg -f h264 -framerate 60 -i unix:///tmp/test -c:v libx264 -preset fast -crf 23 -pix_fmt yuv420p test.mp4"
+# This option enables IDR frames every 30 frames and on socket connection
+base_capture_settings.recording_socket = None
+
 # ==============================================================================
 # --- Multi-Client State Management ---
 # ==============================================================================

--- a/pixelflux_wayland/src/encoders/nvenc.rs
+++ b/pixelflux_wayland/src/encoders/nvenc.rs
@@ -534,6 +534,8 @@ impl NvencEncoder {
             config.encodeCodecConfig.h264Config.chromaFormatIDC = if is_444 { 3 } else { 1 };
             config.encodeCodecConfig.h264Config.h264VUIParameters.videoFullRangeFlag =
                 if is_444 { 1 } else { 0 };
+            config.encodeCodecConfig.h264Config.set_repeatSPSPPS(1);
+            config.encodeCodecConfig.h264Config.set_outputAUD(1);
 
             let mut init_params = NV_ENC_INITIALIZE_PARAMS {
                 version: NV_ENC_INITIALIZE_PARAMS_VER,
@@ -732,11 +734,6 @@ impl NvencEncoder {
         if data_size > 0 && !data_ptr.is_null() {
             let slice = std::slice::from_raw_parts(data_ptr, data_size);
             output.extend_from_slice(slice);
-            // Out-of-band recording tap. NVENC defaults to Annex-B output
-            // for H.264 with the standard preset (no NV_ENC_CONFIG_H264_VUI
-            // override of outputAUD/outputPictureTimingSEI), so the slice is
-            // a valid H.264 elementary stream the way `ffmpeg -f h264 -i
-            // unix://...` expects.
             if let Some(ref sink) = self.recording_sink {
                 sink.write_frame(slice);
             }

--- a/pixelflux_wayland/src/encoders/nvenc.rs
+++ b/pixelflux_wayland/src/encoders/nvenc.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use libloading::{Library, Symbol};
 use smithay::backend::allocator::{dmabuf::Dmabuf, Buffer};
 
+use crate::recording_sink::RecordingSink;
 use crate::RustCaptureSettings;
 use nvenc_sys::cuda::*;
 use nvenc_sys::*;
@@ -183,6 +184,7 @@ pub struct NvencEncoder {
     egl: Arc<EglFunctions>,
     _nvenc_lib: Arc<NvencLibrary>,
     nvenc_funcs: NV_ENCODE_API_FUNCTION_LIST,
+    recording_sink: Option<Arc<RecordingSink>>,
 }
 
 unsafe impl Send for NvencEncoder {}
@@ -409,6 +411,7 @@ impl NvencEncoder {
     pub fn new(
         settings: &RustCaptureSettings,
         egl_display: *const c_void,
+        recording_sink: Option<Arc<RecordingSink>>,
     ) -> Result<Self, String> {
         println!("[NVENC] Initializing...");
 
@@ -621,6 +624,7 @@ impl NvencEncoder {
                 egl,
                 _nvenc_lib: nvenc_lib,
                 nvenc_funcs: function_list,
+                recording_sink,
             })
         }
     }
@@ -726,7 +730,16 @@ impl NvencEncoder {
         output.extend_from_slice(&(self.height as u16).to_be_bytes());
 
         if data_size > 0 && !data_ptr.is_null() {
-            output.extend_from_slice(std::slice::from_raw_parts(data_ptr, data_size));
+            let slice = std::slice::from_raw_parts(data_ptr, data_size);
+            output.extend_from_slice(slice);
+            // Out-of-band recording tap. NVENC defaults to Annex-B output
+            // for H.264 with the standard preset (no NV_ENC_CONFIG_H264_VUI
+            // override of outputAUD/outputPictureTimingSEI), so the slice is
+            // a valid H.264 elementary stream the way `ffmpeg -f h264 -i
+            // unix://...` expects.
+            if let Some(ref sink) = self.recording_sink {
+                sink.write_frame(slice);
+            }
         }
 
         (self.nvenc_funcs.nvEncUnlockBitstream.unwrap())(self.encoder_session, output_bitstream);

--- a/pixelflux_wayland/src/encoders/software.rs
+++ b/pixelflux_wayland/src/encoders/software.rs
@@ -193,11 +193,6 @@ impl H264EncoderWrapper {
                 for nal in nal_slice {
                     let payload = std::slice::from_raw_parts(nal.p_payload, nal.i_payload as usize);
                     output_buf.extend_from_slice(payload);
-                    // Out-of-band recording tap: x264 is configured with
-                    // `b_annexb=1` (see Self::new) so each NAL payload begins
-                    // with the standard 00 00 00 01 start code. Concatenated
-                    // NALs form a valid H.264 elementary stream that
-                    // `ffmpeg -f h264 -i unix://...` reads natively.
                     if let Some(sink) = recording_sink {
                         sink.write_frame(payload);
                     }
@@ -313,13 +308,6 @@ pub fn encode_cpu(
     let trigger_frames = settings.paint_over_trigger_frames;
     let use_paint_over = settings.use_paint_over_quality;
     let target_fps = settings.target_fps;
-
-    // The recording tap only emits a coherent H.264 elementary stream when
-    // exactly one stripe is encoding the whole frame. With N>1 stripes, each
-    // encoder produces an independent sub-frame stream and concatenating them
-    // would yield garbled bytes. We only forward the sink to the inner encoder
-    // when n_processing_stripes==1; multi-stripe configurations silently skip
-    // the tap (the bind warning at StartCapture time tells operators why).
     let stripe_sink: Option<Arc<RecordingSink>> = if n_processing_stripes == 1 {
         recording_sink.cloned()
     } else {
@@ -517,10 +505,6 @@ pub fn encode_cpu(
                         fixed_header[4..6].copy_from_slice(&(width_usize as u16).to_be_bytes());
                         fixed_header[6..8].copy_from_slice(&(actual_height as u16).to_be_bytes());
 
-                        // Periodic IDR for the recording sink: pixelflux's
-                        // baseline encoder uses keyint=INFINITE for WebRTC
-                        // latency, but mid-stream consumers and segment-
-                        // muxing recorders need a keyframe every ~2 s.
                         let force_idr_for_recording = stripe_sink
                             .as_ref()
                             .map(|s| s.should_force_idr())

--- a/pixelflux_wayland/src/encoders/software.rs
+++ b/pixelflux_wayland/src/encoders/software.rs
@@ -1,8 +1,10 @@
+use crate::recording_sink::RecordingSink;
 use crate::RustCaptureSettings;
 use rayon::prelude::*;
 use smithay::utils::{Physical, Rectangle};
 use std::ffi::CString;
 use std::ptr;
+use std::sync::Arc;
 use yuv::{BufferStoreMut, YuvConversionMode, YuvPlanarImageMut, YuvRange, YuvStandardMatrix};
 
 /// @brief Maximum number of stripes used for CPU encoding.
@@ -132,6 +134,7 @@ impl H264EncoderWrapper {
         force_idr: bool,
         fixed_header: &[u8],
         output_buf: &mut Vec<u8>,
+        recording_sink: Option<&Arc<RecordingSink>>,
     ) -> bool {
         unsafe {
             let mut pic_in: x264_sys::x264_picture_t = std::mem::zeroed();
@@ -190,6 +193,14 @@ impl H264EncoderWrapper {
                 for nal in nal_slice {
                     let payload = std::slice::from_raw_parts(nal.p_payload, nal.i_payload as usize);
                     output_buf.extend_from_slice(payload);
+                    // Out-of-band recording tap: x264 is configured with
+                    // `b_annexb=1` (see Self::new) so each NAL payload begins
+                    // with the standard 00 00 00 01 start code. Concatenated
+                    // NALs form a valid H.264 elementary stream that
+                    // `ffmpeg -f h264 -i unix://...` reads natively.
+                    if let Some(sink) = recording_sink {
+                        sink.write_frame(payload);
+                    }
                 }
                 return true;
             }
@@ -237,6 +248,7 @@ pub fn encode_cpu(
     settings: &RustCaptureSettings,
     frame_counter: u16,
     use_gpu: bool,
+    recording_sink: Option<&Arc<RecordingSink>>,
 ) -> Vec<Vec<u8>> {
     let num_cores = std::thread::available_parallelism()
         .map(|n| n.get())
@@ -301,6 +313,18 @@ pub fn encode_cpu(
     let trigger_frames = settings.paint_over_trigger_frames;
     let use_paint_over = settings.use_paint_over_quality;
     let target_fps = settings.target_fps;
+
+    // The recording tap only emits a coherent H.264 elementary stream when
+    // exactly one stripe is encoding the whole frame. With N>1 stripes, each
+    // encoder produces an independent sub-frame stream and concatenating them
+    // would yield garbled bytes. We only forward the sink to the inner encoder
+    // when n_processing_stripes==1; multi-stripe configurations silently skip
+    // the tap (the bind warning at StartCapture time tells operators why).
+    let stripe_sink: Option<Arc<RecordingSink>> = if n_processing_stripes == 1 {
+        recording_sink.cloned()
+    } else {
+        None
+    };
 
     stripes
         .par_iter_mut()
@@ -493,6 +517,15 @@ pub fn encode_cpu(
                         fixed_header[4..6].copy_from_slice(&(width_usize as u16).to_be_bytes());
                         fixed_header[6..8].copy_from_slice(&(actual_height as u16).to_be_bytes());
 
+                        // Periodic IDR for the recording sink: pixelflux's
+                        // baseline encoder uses keyint=INFINITE for WebRTC
+                        // latency, but mid-stream consumers and segment-
+                        // muxing recorders need a keyframe every ~2 s.
+                        let force_idr_for_recording = stripe_sink
+                            .as_ref()
+                            .map(|s| s.should_force_idr())
+                            .unwrap_or(false);
+
                         if enc.encode_with_headers(
                             &stripe_state.y_buf,
                             &stripe_state.u_buf,
@@ -501,9 +534,10 @@ pub fn encode_cpu(
                             uv_stride,
                             uv_stride,
                             frame_counter as i64,
-                            force_idr,
+                            force_idr || force_idr_for_recording,
                             &fixed_header,
                             &mut stripe_state.packet_buf,
+                            stripe_sink.as_ref(),
                         ) {
                             Some(stripe_state.packet_buf.clone())
                         } else {

--- a/pixelflux_wayland/src/encoders/vaapi.rs
+++ b/pixelflux_wayland/src/encoders/vaapi.rs
@@ -7,6 +7,9 @@ use std::sync::Once;
 use ffmpeg_sys_next as ff;
 use libc::{close, dup};
 
+use std::sync::Arc;
+
+use crate::recording_sink::RecordingSink;
 use crate::RustCaptureSettings;
 use smithay::backend::allocator::{dmabuf::Dmabuf, Buffer};
 
@@ -105,9 +108,11 @@ pub struct VaapiEncoder {
     width: i32,
     height: i32,
     fps: i32,
-    
+
     current_qp: u32,
     qp_hysteresis_counter: u32,
+
+    recording_sink: Option<Arc<RecordingSink>>,
 }
 
 unsafe impl Send for VaapiEncoder {}
@@ -160,7 +165,10 @@ impl VaapiEncoder {
     ///
     /// @input settings: Capture configuration (resolution, FPS, QP, render node).
     /// @return Result containing the new VaapiEncoder instance.
-    pub fn new(settings: &RustCaptureSettings) -> Result<Self, String> {
+    pub fn new(
+        settings: &RustCaptureSettings,
+        recording_sink: Option<Arc<RecordingSink>>,
+    ) -> Result<Self, String> {
         FF_INIT.call_once(|| {});
 
         let width = settings.width;
@@ -387,6 +395,7 @@ impl VaapiEncoder {
                 fps,
                 current_qp: settings.h264_crf as u32,
                 qp_hysteresis_counter: 0,
+                recording_sink,
             })
         }
     }
@@ -481,6 +490,13 @@ impl VaapiEncoder {
 
             let slice = std::slice::from_raw_parts(data, size);
             output.extend_from_slice(slice);
+            // Out-of-band recording tap: VAAPI/FFmpeg emits Annex-B framed
+            // H.264 by default for the H.264 codec, matching what
+            // `ffmpeg -f h264 -i unix://...` reads. Same bytes that go to
+            // the Python callback, minus pixelflux's 8-byte custom header.
+            if let Some(ref sink) = self.recording_sink {
+                sink.write_frame(slice);
+            }
 
             ff::av_packet_unref(self.packet);
         }

--- a/pixelflux_wayland/src/encoders/vaapi.rs
+++ b/pixelflux_wayland/src/encoders/vaapi.rs
@@ -164,6 +164,7 @@ impl VaapiEncoder {
     /// frame contexts, and configures the FFmpeg filter graph for color conversion.
     ///
     /// @input settings: Capture configuration (resolution, FPS, QP, render node).
+    /// @input recording_sink: Optional Unix socket sink for encoded output.
     /// @return Result containing the new VaapiEncoder instance.
     pub fn new(
         settings: &RustCaptureSettings,
@@ -490,10 +491,6 @@ impl VaapiEncoder {
 
             let slice = std::slice::from_raw_parts(data, size);
             output.extend_from_slice(slice);
-            // Out-of-band recording tap: VAAPI/FFmpeg emits Annex-B framed
-            // H.264 by default for the H.264 codec, matching what
-            // `ffmpeg -f h264 -i unix://...` reads. Same bytes that go to
-            // the Python callback, minus pixelflux's 8-byte custom header.
             if let Some(ref sink) = self.recording_sink {
                 sink.write_frame(slice);
             }

--- a/pixelflux_wayland/src/lib.rs
+++ b/pixelflux_wayland/src/lib.rs
@@ -199,10 +199,6 @@ pub struct RustCaptureSettings {
     pub vaapi_render_node_index: i32,
     pub use_cpu: bool,
     pub debug_logging: bool,
-    /// Path to a Unix domain socket pixelflux will bind for an out-of-band
-    /// fanout of the encoded H.264 elementary stream. Empty string disables
-    /// the feature; the `PIXELFLUX_RECORDING_SOCKET` env var is consulted
-    /// as a fallback. See [`crate::recording_sink`] for details.
     pub recording_socket: String,
 }
 
@@ -548,27 +544,8 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                         }
                     }
 
-                    // Bind the optional out-of-band recording sink. With the CPU encoder
-                    // this only produces a muxable H.264 elementary stream when
-                    // `h264_fullframe=true` (single-stripe mode); VAAPI/NVENC always
-                    // produce a single stream and tap cleanly. When the multi-stripe CPU
-                    // path is active, the recording sink is still bound but receives no
-                    // data — log a warning so operators notice the misconfiguration.
                     state.recording_sink =
                         crate::recording_sink::RecordingSink::try_bind(&settings.recording_socket);
-                    if state.recording_sink.is_some()
-                        && settings.use_cpu
-                        && !settings.h264_fullframe
-                    {
-                        eprintln!(
-                            "[recording_sink] WARNING: recording_socket is set but use_cpu=true \
-                             and h264_fullframe=false. The CPU encoder runs in multi-stripe \
-                             mode by default, which produces N independent sub-frame H.264 \
-                             streams that cannot be muxed together. Set h264_fullframe=true \
-                             on the Python CaptureSettings (or upgrade to a GPU encoder) to \
-                             produce a recordable single-stream output."
-                        );
-                    }
 
                     if let Some(output) = state.outputs.first() {
                         let current_mode = output.current_mode().unwrap();
@@ -741,6 +718,23 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                         n_stripes = n_stripes.min(settings.height as usize).max(1);
                     }
 
+                    if state.recording_sink.is_some() {
+                        if settings.output_mode == 0 {
+                            eprintln!(
+                                "[recording_sink] WARNING: recording_socket is set but output_mode is JPEG (0). \
+                                 The recording sink requires a single H.264 stream. Please set output_mode=1 \
+                                 on the Python CaptureSettings to produce a recordable output."
+                            );
+                        } else if state.video_encoder.is_none() && !settings.h264_fullframe {
+                            eprintln!(
+                                "[recording_sink] WARNING: recording_socket is set but the CPU encoder is running in \
+                                 multi-stripe mode. This produces N independent sub-frame H.264 streams that \
+                                 cannot be muxed together. Set h264_fullframe=true on the Python CaptureSettings \
+                                 (or use a working GPU encoder) to produce a recordable single-stream output."
+                            );
+                        }
+                    }
+
                     let mut log_msg = format!(
                         "Stream settings active -> Res: {}x{} | FPS: {:.1} | Stripes: {}",
                         settings.width, settings.height, settings.target_fps, n_stripes
@@ -822,9 +816,6 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                     state.is_capturing = false;
                     state.callback = None;
                     state.video_encoder = None;
-                    // Drop the recording sink: the listener thread observes the shutdown
-                    // flag and exits, the socket file is unlinked, and any connected
-                    // clients see EOF on their next read.
                     state.recording_sink = None;
                 }
                 CalloopEvent::Msg(ThreadCommand::SetCursorCallback(cb)) => {
@@ -1611,10 +1602,6 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                         }
 
                         if send_frame {
-                            // Periodic IDR injection: pixelflux's baseline
-                            // encoders use keyint=INFINITE for WebRTC latency,
-                            // but mid-stream recording consumers and segment-
-                            // muxing tools need a keyframe every ~2 s.
                             let force_idr_for_recording = state
                                 .recording_sink
                                 .as_ref()

--- a/pixelflux_wayland/src/lib.rs
+++ b/pixelflux_wayland/src/lib.rs
@@ -98,6 +98,7 @@ pub mod encoders {
 }
 
 pub mod wayland;
+pub mod recording_sink;
 
 pub use encoders::nvenc;
 pub use encoders::software::StripeState;
@@ -198,6 +199,11 @@ pub struct RustCaptureSettings {
     pub vaapi_render_node_index: i32,
     pub use_cpu: bool,
     pub debug_logging: bool,
+    /// Path to a Unix domain socket pixelflux will bind for an out-of-band
+    /// fanout of the encoded H.264 elementary stream. Empty string disables
+    /// the feature; the `PIXELFLUX_RECORDING_SOCKET` env var is consulted
+    /// as a fallback. See [`crate::recording_sink`] for details.
+    pub recording_socket: String,
 }
 
 impl Default for RustCaptureSettings {
@@ -228,6 +234,7 @@ impl Default for RustCaptureSettings {
             vaapi_render_node_index: -1,
             use_cpu: false,
             debug_logging: false,
+            recording_socket: String::new(),
         }
     }
 }
@@ -496,6 +503,7 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
         cursor_cache: std::collections::HashMap::new(),
         render_cursor_on_framebuffer: false,
         render_node_path,
+        recording_sink: None,
     };
 
     let output = Output::new(
@@ -538,6 +546,28 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                                 settings.vaapi_render_node_index = idx - 128;
                             }
                         }
+                    }
+
+                    // Bind the optional out-of-band recording sink. With the CPU encoder
+                    // this only produces a muxable H.264 elementary stream when
+                    // `h264_fullframe=true` (single-stripe mode); VAAPI/NVENC always
+                    // produce a single stream and tap cleanly. When the multi-stripe CPU
+                    // path is active, the recording sink is still bound but receives no
+                    // data — log a warning so operators notice the misconfiguration.
+                    state.recording_sink =
+                        crate::recording_sink::RecordingSink::try_bind(&settings.recording_socket);
+                    if state.recording_sink.is_some()
+                        && settings.use_cpu
+                        && !settings.h264_fullframe
+                    {
+                        eprintln!(
+                            "[recording_sink] WARNING: recording_socket is set but use_cpu=true \
+                             and h264_fullframe=false. The CPU encoder runs in multi-stripe \
+                             mode by default, which produces N independent sub-frame H.264 \
+                             streams that cannot be muxed together. Set h264_fullframe=true \
+                             on the Python CaptureSettings (or upgrade to a GPU encoder) to \
+                             produce a recordable single-stream output."
+                        );
                     }
 
                     if let Some(output) = state.outputs.first() {
@@ -639,7 +669,7 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                                 std::ptr::null()
                             };
 
-                            match NvencEncoder::new(&settings, egl_display) {
+                            match NvencEncoder::new(&settings, egl_display, state.recording_sink.clone()) {
                                 Ok(encoder) => {
                                     state.video_encoder = Some(GpuEncoder::Nvenc(encoder));
                                     println!("[Wayland] NVENC Encoder initialized successfully.");
@@ -654,7 +684,7 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                             if settings.h264_fullcolor {
                                 println!("[Wayland] 4:4:4 Fullcolor requested. VAAPI does not support this profile reliably. Falling back to CPU.");
                             } else {
-                                match VaapiEncoder::new(&settings) {
+                                match VaapiEncoder::new(&settings, state.recording_sink.clone()) {
                                     Ok(encoder) => {
                                         state.video_encoder = Some(GpuEncoder::Vaapi(encoder));
                                         println!(
@@ -792,6 +822,10 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                     state.is_capturing = false;
                     state.callback = None;
                     state.video_encoder = None;
+                    // Drop the recording sink: the listener thread observes the shutdown
+                    // flag and exits, the socket file is unlinked, and any connected
+                    // clients see EOF on their next read.
+                    state.recording_sink = None;
                 }
                 CalloopEvent::Msg(ThreadCommand::SetCursorCallback(cb)) => {
                     state.cursor_callback = Some(cb);
@@ -1577,6 +1611,16 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                         }
 
                         if send_frame {
+                            // Periodic IDR injection: pixelflux's baseline
+                            // encoders use keyint=INFINITE for WebRTC latency,
+                            // but mid-stream recording consumers and segment-
+                            // muxing tools need a keyframe every ~2 s.
+                            let force_idr_for_recording = state
+                                .recording_sink
+                                .as_ref()
+                                .map(|s| s.should_force_idr())
+                                .unwrap_or(false);
+                            let force_idr = force_idr || force_idr_for_recording;
                             let result = match encoder {
                                 GpuEncoder::Nvenc(enc) => {
                                     if needs_readback {
@@ -1632,6 +1676,7 @@ fn run_wayland_thread(command_rx: smithay::reexports::calloop::channel::Channel<
                             &state.settings,
                             state.frame_counter,
                             state.use_gpu,
+                            state.recording_sink.as_ref(),
                         );
 
                         if !encoded_packets.is_empty() {
@@ -1729,6 +1774,11 @@ impl WaylandBackend {
             vaapi_render_node_index: settings.getattr("vaapi_render_node_index")?.extract()?,
             use_cpu: settings.getattr("use_cpu")?.extract()?,
             debug_logging: settings.getattr("debug_logging")?.extract()?,
+            recording_socket: settings
+                .getattr("recording_socket")
+                .ok()
+                .and_then(|v| v.extract::<String>().ok())
+                .unwrap_or_default(),
         };
 
         self.tx

--- a/pixelflux_wayland/src/recording_sink.rs
+++ b/pixelflux_wayland/src/recording_sink.rs
@@ -1,0 +1,219 @@
+//! Optional out-of-band sink for the encoded H.264 elementary stream.
+//!
+//! When enabled (via `RustCaptureSettings::recording_socket` or the
+//! `PIXELFLUX_RECORDING_SOCKET` environment variable), pixelflux binds a Unix
+//! domain socket and accepts an arbitrary number of consumers. Each encoder
+//! calls [`RecordingSink::write_frame`] once per produced NAL unit; the sink
+//! fans the bytes out to every connected client.
+//!
+//! The wire format is the encoder's native Annex-B H.264 — exactly the bytes
+//! that already get concatenated into the Python callback's `output_buf`,
+//! minus pixelflux's 2-byte custom framing header. This makes the stream
+//! consumable by `ffmpeg -f h264 -i unix:///<path> -c:v copy ...` with no
+//! custom parser on the consumer side.
+//!
+//! ## Lifecycle
+//!
+//! * `RecordingSink::try_bind` is called at encoder construction. It removes
+//!   any stale socket file, binds a non-blocking [`UnixListener`], and spawns
+//!   a dedicated accept thread that polls every 50 ms for new clients.
+//! * Each accepted client gets a 100 ms write timeout (`SO_SNDTIMEO`). A slow
+//!   or hung consumer is closed on the next encode call rather than back-
+//!   pressuring pixelflux's encode loop.
+//! * `write_frame` iterates the connected clients under a mutex, attempts a
+//!   blocking `write_all` (bounded by the timeout), and prunes any client
+//!   whose write returned an error (`EPIPE`, `ETIMEDOUT`, …).
+//! * On `Drop`, the listener thread is signalled to exit and the socket file
+//!   is removed.
+//!
+//! ## Mid-stream joiners
+//!
+//! A client that connects mid-session sees arbitrary frames before the next
+//! IDR ("keyframe"). Standard H.264 decoders skip until the next IDR finds
+//! them; ffmpeg handles this transparently. Forcing an IDR on every new
+//! connection is left as a future enhancement — kept out of scope here to
+//! keep the patch minimal.
+
+use std::fs;
+use std::io::{ErrorKind, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+/// Per-client write timeout. A slow consumer is closed rather than blocking
+/// the encoder thread.
+const WRITE_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// Cadence at which the accept thread polls for new clients.
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Environment variable consulted as a fallback when
+/// `RustCaptureSettings::recording_socket` is empty.
+pub const RECORDING_SOCKET_ENV: &str = "PIXELFLUX_RECORDING_SOCKET";
+
+/// Default keyframe cadence — emit an IDR every N encoded frames whenever
+/// the sink is active. At pixelflux's typical 30 fps this places an IDR
+/// every ~2 s, which lets a mid-stream consumer start decoding within that
+/// bound and lets `ffmpeg -f segment -segment_time 2` cut clean segments.
+/// Pixelflux's bare encoder uses `KEYINT_MAX_INFINITE` for WebRTC latency;
+/// the sink overrides this only when recording is in use.
+const DEFAULT_KEYINT_FRAMES: u32 = 60;
+
+pub struct RecordingSink {
+    path: String,
+    clients: Arc<Mutex<Vec<UnixStream>>>,
+    shutdown: Arc<AtomicBool>,
+    /// Frames since the last forced IDR. Touched by two threads:
+    /// the accept loop resets it to `u32::MAX` whenever a new client
+    /// arrives (so the next encode is a keyframe for the new consumer),
+    /// and the encoder's `should_force_idr` increments / resets to 0
+    /// after each forced keyframe. Periodic IDRs every `keyint_frames`
+    /// frames cover the steady-state segment-rotation case.
+    frames_since_idr: Arc<AtomicU32>,
+    keyint_frames: u32,
+}
+
+impl RecordingSink {
+    /// Resolve the configured socket path and try to bind it.
+    ///
+    /// Precedence: `settings_path` (if non-empty) > `PIXELFLUX_RECORDING_SOCKET`
+    /// env var (if set and non-empty) > `None` (recording disabled).
+    ///
+    /// Bind failures are logged but never panic — pixelflux's main pipeline
+    /// continues unaffected.
+    pub fn try_bind(settings_path: &str) -> Option<Arc<Self>> {
+        let path = if !settings_path.is_empty() {
+            settings_path.to_string()
+        } else {
+            match std::env::var(RECORDING_SOCKET_ENV) {
+                Ok(p) if !p.is_empty() => p,
+                _ => return None,
+            }
+        };
+
+        match Self::bind(path) {
+            Ok(sink) => Some(Arc::new(sink)),
+            Err(e) => {
+                eprintln!("[recording_sink] bind failed: {:?}", e);
+                None
+            }
+        }
+    }
+
+    fn bind(path: String) -> std::io::Result<Self> {
+        // Stale socket files can survive an unclean shutdown of a previous
+        // pixelflux process; remove unconditionally before bind.
+        let _ = fs::remove_file(&path);
+
+        let listener = UnixListener::bind(&path)?;
+        listener.set_nonblocking(true)?;
+
+        let clients: Arc<Mutex<Vec<UnixStream>>> = Arc::new(Mutex::new(Vec::new()));
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        // The accept loop and the encode loop both touch this counter:
+        // accept resets it to u32::MAX so the next encode emits an IDR
+        // (giving the new client a clean decoding entry point); the
+        // encoder's should_force_idr increments it and resets to 0 after
+        // each forced keyframe. Wrapped in Arc so both threads share it.
+        let frames_since_idr = Arc::new(AtomicU32::new(u32::MAX));
+
+        let clients_acc = clients.clone();
+        let shutdown_acc = shutdown.clone();
+        let frames_since_idr_acc = frames_since_idr.clone();
+        let path_log = path.clone();
+        thread::spawn(move || {
+            eprintln!("[recording_sink] listening on {}", path_log);
+            while !shutdown_acc.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(e) = stream.set_write_timeout(Some(WRITE_TIMEOUT)) {
+                            eprintln!("[recording_sink] set_write_timeout failed: {:?}", e);
+                            continue;
+                        }
+                        let mut guard = clients_acc.lock().unwrap();
+                        guard.push(stream);
+                        // Trigger an IDR on the encoder's next call so the
+                        // newly-attached consumer has SPS/PPS + a keyframe
+                        // to start decoding from.
+                        frames_since_idr_acc.store(u32::MAX, Ordering::Relaxed);
+                        eprintln!(
+                            "[recording_sink] client connected; total {}; requesting IDR",
+                            guard.len()
+                        );
+                    }
+                    Err(e) if e.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(ACCEPT_POLL_INTERVAL);
+                    }
+                    Err(e) => {
+                        eprintln!("[recording_sink] accept error: {:?}", e);
+                        thread::sleep(Duration::from_millis(500));
+                    }
+                }
+            }
+            eprintln!("[recording_sink] listener thread exiting");
+        });
+
+        Ok(Self {
+            path,
+            clients,
+            shutdown,
+            frames_since_idr,
+            keyint_frames: DEFAULT_KEYINT_FRAMES,
+        })
+    }
+
+    /// Advisory hook for encoders: returns `true` when the next encode
+    /// should be an IDR (keyframe with SPS+PPS). Encoders should OR this
+    /// into their own `force_idr` flag before calling into x264/VAAPI/NVENC.
+    ///
+    /// Bumps the internal frame counter each call. The very first call
+    /// after sink construction returns `true`; subsequent calls return
+    /// `true` every `keyint_frames` increments. This is the periodic-IDR
+    /// behaviour pixelflux's bare encoder doesn't provide on its own (its
+    /// keyint is `INFINITE` for WebRTC latency).
+    pub fn should_force_idr(&self) -> bool {
+        // Saturating add avoids wrap-around weirdness in the rare case the
+        // counter is already u32::MAX from initialisation.
+        let prev = self.frames_since_idr.fetch_add(1, Ordering::Relaxed);
+        if prev >= self.keyint_frames - 1 {
+            self.frames_since_idr.store(0, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Fan a chunk of encoded bytes out to every connected client.
+    ///
+    /// `data` is expected to be raw Annex-B H.264 — typically a single NAL
+    /// unit's `p_payload` (software encoder) or the locked NVENC bitstream
+    /// segment (NVENC encoder), or the corresponding VAAPI output. The
+    /// boundary between calls does not need to align with H.264 frame
+    /// boundaries; ffmpeg's H.264 demuxer parses start codes natively.
+    pub fn write_frame(&self, data: &[u8]) {
+        if data.is_empty() {
+            return;
+        }
+        let mut clients = self.clients.lock().unwrap();
+        let mut to_remove: Vec<usize> = Vec::new();
+        for (idx, client) in clients.iter_mut().enumerate() {
+            if let Err(e) = client.write_all(data) {
+                eprintln!("[recording_sink] dropping client (idx {}): {:?}", idx, e);
+                to_remove.push(idx);
+            }
+        }
+        for idx in to_remove.into_iter().rev() {
+            clients.swap_remove(idx);
+        }
+    }
+}
+
+impl Drop for RecordingSink {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/pixelflux_wayland/src/recording_sink.rs
+++ b/pixelflux_wayland/src/recording_sink.rs
@@ -1,39 +1,3 @@
-//! Optional out-of-band sink for the encoded H.264 elementary stream.
-//!
-//! When enabled (via `RustCaptureSettings::recording_socket` or the
-//! `PIXELFLUX_RECORDING_SOCKET` environment variable), pixelflux binds a Unix
-//! domain socket and accepts an arbitrary number of consumers. Each encoder
-//! calls [`RecordingSink::write_frame`] once per produced NAL unit; the sink
-//! fans the bytes out to every connected client.
-//!
-//! The wire format is the encoder's native Annex-B H.264 — exactly the bytes
-//! that already get concatenated into the Python callback's `output_buf`,
-//! minus pixelflux's 2-byte custom framing header. This makes the stream
-//! consumable by `ffmpeg -f h264 -i unix:///<path> -c:v copy ...` with no
-//! custom parser on the consumer side.
-//!
-//! ## Lifecycle
-//!
-//! * `RecordingSink::try_bind` is called at encoder construction. It removes
-//!   any stale socket file, binds a non-blocking [`UnixListener`], and spawns
-//!   a dedicated accept thread that polls every 50 ms for new clients.
-//! * Each accepted client gets a 100 ms write timeout (`SO_SNDTIMEO`). A slow
-//!   or hung consumer is closed on the next encode call rather than back-
-//!   pressuring pixelflux's encode loop.
-//! * `write_frame` iterates the connected clients under a mutex, attempts a
-//!   blocking `write_all` (bounded by the timeout), and prunes any client
-//!   whose write returned an error (`EPIPE`, `ETIMEDOUT`, …).
-//! * On `Drop`, the listener thread is signalled to exit and the socket file
-//!   is removed.
-//!
-//! ## Mid-stream joiners
-//!
-//! A client that connects mid-session sees arbitrary frames before the next
-//! IDR ("keyframe"). Standard H.264 decoders skip until the next IDR finds
-//! them; ffmpeg handles this transparently. Forcing an IDR on every new
-//! connection is left as a future enhancement — kept out of scope here to
-//! keep the patch minimal.
-
 use std::fs;
 use std::io::{ErrorKind, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -42,47 +6,29 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-/// Per-client write timeout. A slow consumer is closed rather than blocking
-/// the encoder thread.
+/// Core settings and state for the out-of-band H.264 recording sink.
+///
+/// Defines socket connection timeouts, polling intervals, environment fallbacks,
+/// keyframe cadence, and the primary RecordingSink structure used to multiplex
+/// the elementary stream to connected Unix socket clients.
 const WRITE_TIMEOUT: Duration = Duration::from_millis(100);
-
-/// Cadence at which the accept thread polls for new clients.
 const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(50);
-
-/// Environment variable consulted as a fallback when
-/// `RustCaptureSettings::recording_socket` is empty.
 pub const RECORDING_SOCKET_ENV: &str = "PIXELFLUX_RECORDING_SOCKET";
-
-/// Default keyframe cadence — emit an IDR every N encoded frames whenever
-/// the sink is active. At pixelflux's typical 30 fps this places an IDR
-/// every ~2 s, which lets a mid-stream consumer start decoding within that
-/// bound and lets `ffmpeg -f segment -segment_time 2` cut clean segments.
-/// Pixelflux's bare encoder uses `KEYINT_MAX_INFINITE` for WebRTC latency;
-/// the sink overrides this only when recording is in use.
 const DEFAULT_KEYINT_FRAMES: u32 = 60;
 
 pub struct RecordingSink {
     path: String,
     clients: Arc<Mutex<Vec<UnixStream>>>,
     shutdown: Arc<AtomicBool>,
-    /// Frames since the last forced IDR. Touched by two threads:
-    /// the accept loop resets it to `u32::MAX` whenever a new client
-    /// arrives (so the next encode is a keyframe for the new consumer),
-    /// and the encoder's `should_force_idr` increments / resets to 0
-    /// after each forced keyframe. Periodic IDRs every `keyint_frames`
-    /// frames cover the steady-state segment-rotation case.
     frames_since_idr: Arc<AtomicU32>,
     keyint_frames: u32,
 }
 
 impl RecordingSink {
-    /// Resolve the configured socket path and try to bind it.
+    /// @brief Resolves the configured socket path and tries to bind it.
     ///
-    /// Precedence: `settings_path` (if non-empty) > `PIXELFLUX_RECORDING_SOCKET`
-    /// env var (if set and non-empty) > `None` (recording disabled).
-    ///
-    /// Bind failures are logged but never panic — pixelflux's main pipeline
-    /// continues unaffected.
+    /// @input settings_path: The configured path for the socket.
+    /// @return Option containing the new RecordingSink instance.
     pub fn try_bind(settings_path: &str) -> Option<Arc<Self>> {
         let path = if !settings_path.is_empty() {
             settings_path.to_string()
@@ -102,9 +48,11 @@ impl RecordingSink {
         }
     }
 
+    /// @brief Binds the Unix listener and spawns the accept thread.
+    ///
+    /// @input path: The file path to bind the socket to.
+    /// @return Result containing the new RecordingSink instance.
     fn bind(path: String) -> std::io::Result<Self> {
-        // Stale socket files can survive an unclean shutdown of a previous
-        // pixelflux process; remove unconditionally before bind.
         let _ = fs::remove_file(&path);
 
         let listener = UnixListener::bind(&path)?;
@@ -113,17 +61,13 @@ impl RecordingSink {
         let clients: Arc<Mutex<Vec<UnixStream>>> = Arc::new(Mutex::new(Vec::new()));
         let shutdown = Arc::new(AtomicBool::new(false));
 
-        // The accept loop and the encode loop both touch this counter:
-        // accept resets it to u32::MAX so the next encode emits an IDR
-        // (giving the new client a clean decoding entry point); the
-        // encoder's should_force_idr increments it and resets to 0 after
-        // each forced keyframe. Wrapped in Arc so both threads share it.
         let frames_since_idr = Arc::new(AtomicU32::new(u32::MAX));
 
         let clients_acc = clients.clone();
         let shutdown_acc = shutdown.clone();
         let frames_since_idr_acc = frames_since_idr.clone();
         let path_log = path.clone();
+
         thread::spawn(move || {
             eprintln!("[recording_sink] listening on {}", path_log);
             while !shutdown_acc.load(Ordering::Relaxed) {
@@ -135,9 +79,7 @@ impl RecordingSink {
                         }
                         let mut guard = clients_acc.lock().unwrap();
                         guard.push(stream);
-                        // Trigger an IDR on the encoder's next call so the
-                        // newly-attached consumer has SPS/PPS + a keyframe
-                        // to start decoding from.
+
                         frames_since_idr_acc.store(u32::MAX, Ordering::Relaxed);
                         eprintln!(
                             "[recording_sink] client connected; total {}; requesting IDR",
@@ -165,18 +107,10 @@ impl RecordingSink {
         })
     }
 
-    /// Advisory hook for encoders: returns `true` when the next encode
-    /// should be an IDR (keyframe with SPS+PPS). Encoders should OR this
-    /// into their own `force_idr` flag before calling into x264/VAAPI/NVENC.
+    /// @brief Advisory hook indicating if the next encode should be an IDR.
     ///
-    /// Bumps the internal frame counter each call. The very first call
-    /// after sink construction returns `true`; subsequent calls return
-    /// `true` every `keyint_frames` increments. This is the periodic-IDR
-    /// behaviour pixelflux's bare encoder doesn't provide on its own (its
-    /// keyint is `INFINITE` for WebRTC latency).
+    /// @return True if the next frame should be a keyframe.
     pub fn should_force_idr(&self) -> bool {
-        // Saturating add avoids wrap-around weirdness in the rare case the
-        // counter is already u32::MAX from initialisation.
         let prev = self.frames_since_idr.fetch_add(1, Ordering::Relaxed);
         if prev >= self.keyint_frames - 1 {
             self.frames_since_idr.store(0, Ordering::Relaxed);
@@ -186,25 +120,24 @@ impl RecordingSink {
         }
     }
 
-    /// Fan a chunk of encoded bytes out to every connected client.
+    /// @brief Fans a chunk of encoded bytes out to every connected client.
     ///
-    /// `data` is expected to be raw Annex-B H.264 — typically a single NAL
-    /// unit's `p_payload` (software encoder) or the locked NVENC bitstream
-    /// segment (NVENC encoder), or the corresponding VAAPI output. The
-    /// boundary between calls does not need to align with H.264 frame
-    /// boundaries; ffmpeg's H.264 demuxer parses start codes natively.
+    /// @input data: The raw Annex-B H.264 byte slice.
     pub fn write_frame(&self, data: &[u8]) {
         if data.is_empty() {
             return;
         }
+
         let mut clients = self.clients.lock().unwrap();
         let mut to_remove: Vec<usize> = Vec::new();
+
         for (idx, client) in clients.iter_mut().enumerate() {
             if let Err(e) = client.write_all(data) {
                 eprintln!("[recording_sink] dropping client (idx {}): {:?}", idx, e);
                 to_remove.push(idx);
             }
         }
+
         for idx in to_remove.into_iter().rev() {
             clients.swap_remove(idx);
         }

--- a/pixelflux_wayland/src/wayland/frontend.rs
+++ b/pixelflux_wayland/src/wayland/frontend.rs
@@ -215,6 +215,7 @@ pub struct AppState {
     pub relative_pointer_state: RelativePointerManagerState,
     pub pointer_constraints_state: PointerConstraintsState,
     pub render_node_path: String,
+    pub recording_sink: Option<Arc<crate::recording_sink::RecordingSink>>,
 }
 
 impl PointerConstraintsHandler for AppState {


### PR DESCRIPTION
## What

Adds a small, opt-in side channel that lets external consumers receive the encoded H.264 elementary stream pixelflux already produces for Selkies/WebRTC. A new `recording_sink` module binds a Unix domain socket and accepts an arbitrary number of clients; each encoder's bitstream-extraction path mirrors the raw NAL bytes into all connected clients without modifying the existing Python-callback contract.

## Why

Use cases that want the same encoded frames the user is seeing in the browser — audit recording, live thumbnailing, archival muxing, … — have no clean entry point today. Re-encoding from a screen-capture protocol like `ext-image-copy-capture-v1` (#14) only works with GPU-equipped clusters (the canonical consumer, `wl-screenrec`, requires `zwp_linux_dmabuf`) and doubles the CPU encoding budget. Tapping the encoded NALs that pixelflux already produces gives a single-encode solution that works on CPU-only deployments and stays bit-identical to what the browser receives.

## Wire format

Raw Annex-B H.264 — exactly the bytes that already get concatenated into the Python callback's `output_buf`, minus pixelflux's 2-byte custom framing header. Consumable by `ffmpeg -f h264 -i unix:///<path> -c:v copy ...` with no custom parser on the consumer side.

## Configuration

Precedence high-to-low:

1. `CaptureSettings.recording_socket` (Python-discoverable, per-session)
2. `PIXELFLUX_RECORDING_SOCKET` env var
3. unset → no-op (the current behaviour for every existing user)

## Encoder coverage

All three encoders are wired with the same single-write tap:

- **Software (x264)** — tap inside `H264EncoderWrapper::encode_with_headers`, right after the existing `output_buf.extend_from_slice(payload)` for each NAL. x264 is configured with `b_annexb=1`, so the per-NAL payload already begins with a `00 00 00 01` start code.
- **VAAPI** — tap inside `VaapiEncoder::collect_packet` (the helper both `encode_dmabuf` and `encode_raw` call). `h264_vaapi` defaults to Annex-B framing.
- **NVENC** — tap inside `NvencEncoder::submit_frame` (the helper both `encode` and `encode_raw` call). NVENC's standard H.264 preset emits Annex-B framed output.

A single ffmpeg consumer can switch between encoder backends without changing its invocation.

## Periodic IDRs

Pixelflux's bare encoder uses `KEYINT_MAX_INFINITE` for low WebRTC latency — after the very first frame, x264/VAAPI/NVENC will only emit P-frames. That breaks two recording use cases: a mid-stream consumer never gets SPS+PPS+IDR to start decoding, and `ffmpeg -f segment` cannot cut clean GOP boundaries.

The sink solves both with a small advisory hook (`RecordingSink::should_force_idr()`) that the encoders consult before each encode. It returns `true`:

- on the very first call (so the first encoded frame after a sink bind is a keyframe);
- whenever a new client `accept()`s on the listener (so a late joiner gets a decoder-ready stream within one encode cycle);
- every 60 calls thereafter (~2 s at 30 fps) for steady-state segment-rotation cleanliness.

The hook is stateless beyond one `AtomicU32`. The encoders OR the result into their existing `force_idr` flag.

## Multi-stripe CPU constraint

When `use_cpu=true && h264_fullframe=false`, `encode_cpu` runs N parallel x264 encoders producing independent sub-frame streams that cannot be muxed together. The recording sink is only forwarded to the inner encoder when `n_processing_stripes==1`; multi-stripe paths silently skip the tap. A startup warning at `start_capture` time tells operators they need `h264_fullframe=true` (or any GPU encoder) to produce a recordable single stream.

## Validation

`cargo check` and `cargo build --release` are clean against the unchanged upstream master.

End-to-end smoke against the CPU encoder, with a `weston-simple-shm` client driving full-screen damage at 1920x1080 / target 30 fps / CRF 25:

| Metric              | Baseline (no tap) | With tap   |
|---------------------|-------------------|------------|
| pixelflux CPU       | ~31 %             | ~32 %      |
| Encode FPS          | ~27               | ~27        |
| ffmpeg CPU          | n/a               | ~2.2 %     |
| File bitrate        | n/a               | ~47 Mbps*  |
| Recording artifact  | n/a               | valid .mkv |

\* The bitrate is for a worst-case synthetic full-screen gradient animation; typical desktop work would be 1-5 Mbps.

Segment-muxer test (`-f segment -segment_time 10`) over ~38 s produced four self-contained ~10 s segments; `ffprobe -count_frames` reports 300 frames per 10 s segment (matches 30 fps × 10 s) and each segment decodes cleanly through `ffmpeg -i seg.mkv -f null -`. The only diagnostics that surface are cosmetic non-monotonic-DTS warnings caused by the bare H.264 elementary stream having no embedded timestamps; a downstream consumer that needs strict timestamps can add `-fps_mode cfr` or `-framerate <n>` on its ffmpeg invocation.

VAAPI and NVENC tap sites were reviewed by code inspection — same single extension point in each encoder's existing extract path — but were not exercised end-to-end (no GPU on the dev host). A reviewer or follow-up with GPU access would close that gap definitively.
