### PR TITLE
Remove SEI option in VAAPI + Other Fixes

### DIFF
--- a/pixelflux/src/encoders/vaapi.rs
+++ b/pixelflux/src/encoders/vaapi.rs
@@ -444,10 +444,6 @@ impl VaapiEncoder {
             }
             set_opt(&mut opts, "async_depth", "1");
             set_opt(&mut opts, "profile", "high");
-            // No SEI: the default identifier/timing/recovery_point units are
-            // consumed by nothing in this pipeline, and SEI-bearing frames can
-            // freeze Chromium m128+ WebRTC clients when packet loss hits them.
-            set_opt(&mut opts, "sei", "0");
             set_opt(&mut opts, "level", "4.1");
 
             let ret = ff::avcodec_open2(encoder_ctx, codec, &mut opts);
@@ -712,10 +708,6 @@ impl VaapiEncoder {
         }
         set_opt(&mut opts, "async_depth", "1");
         set_opt(&mut opts, "profile", "high");
-        // No SEI: the default identifier/timing/recovery_point units are
-        // consumed by nothing in this pipeline, and SEI-bearing frames can
-        // freeze Chromium m128+ WebRTC clients when packet loss hits them.
-        set_opt(&mut opts, "sei", "0");
         set_opt(&mut opts, "level", "4.1");
 
         let ret = ff::avcodec_open2(self.encoder_ctx, self.codec, &mut opts);


### PR DESCRIPTION
The SEI issue has been fixed in Chrome 131. Not necessary.

https://support.dolby.io/hc/en-au/articles/11057317291663-Playback-Issues-with-SEI-Messages-in-H-264-Streaming
https://webrtc-review.googlesource.com/c/src/+/364241